### PR TITLE
Removed rows where there was no votes for any candidate

### DIFF
--- a/structure/us_election_data_quality_check.sql
+++ b/structure/us_election_data_quality_check.sql
@@ -1,184 +1,279 @@
+
 ----------------------------------------------------------------------------------
 --QUALITY CHECK TABLICY COUNTY_FACTS
 ----------------------------------------------------------------------------------
 
 --sprawdzenie, czy fips zawsze dodatni
-select * from county_facts cf 
-where fips < 0 
-or fips isnull ;
+ SELECT *
+FROM
+  county_facts cf
+WHERE
+  fips < 0
+  OR fips isnull ;
 
 --sprawdzenie, czy skrót sk³ada siê zawsze z dwóch liter
-select 
-	count(*)
-,	case	when upper(state_abbreviation) similar to '[A-Z]{2}' then 'valid state abbr'
-			else 'invalid state abbr' end state_abbr_check
-from county_facts cf 
-group by state_abbr_check ;
+ SELECT
+  count(*) ,
+  CASE
+    WHEN upper(state_abbreviation) SIMILAR TO '[A-Z]{2}' THEN 'valid state abbr'
+    ELSE 'invalid state abbr'
+  END state_abbr_check
+FROM
+  county_facts cf
+GROUP BY
+  state_abbr_check ;
 
 --^52 invalid state abbreviation --> 51 stanów + USA
-select 
-	area_name 
-,	state_abbreviation 
-,	case	when upper(state_abbreviation) similar to '[A-Z]{2}' then 'valid state abbr'
-			else 'invalid state abbr' end state_abbr_check
-from county_facts cf 
-order by state_abbr_check, area_name 
-limit 52 ;
+ SELECT
+  area_name ,
+  state_abbreviation ,
+  CASE
+    WHEN upper(state_abbreviation) SIMILAR TO '[A-Z]{2}' THEN 'valid state abbr'
+    ELSE 'invalid state abbr'
+  END state_abbr_check
+FROM
+  county_facts cf
+ORDER BY
+  state_abbr_check,
+  area_name
+LIMIT 52 ;
 
 --sprawdzenie, czy wszystkie hrabstwa maj¹ wpisany state_abbreviation 
 --(oraz czy wszystkie stany maj¹ null w state_abbreviation) 
-select 
-	fips
-,	area_name 
-,	state_abbreviation 
-from county_facts cf 
-where state_abbreviation isnull
-order by fips ;
+ SELECT
+  fips ,
+  area_name ,
+  state_abbreviation
+FROM
+  county_facts cf
+WHERE
+  state_abbreviation isnull
+ORDER BY
+  fips ;
 
-select count(*)
-from county_facts cf 
-where state_abbreviation isnull ;
+SELECT count(*)
+FROM
+  county_facts cf
+WHERE
+  state_abbreviation isnull ;
 
-select 
-	fips
-,	area_name 
-,	state_abbreviation 
-from county_facts cf 
-where state_abbreviation is not null 
-and state_abbreviation not similar to '[A-Z]{2}'
-order by fips ;
-
+SELECT
+  fips ,
+  area_name ,
+  state_abbreviation
+FROM
+  county_facts cf
+WHERE
+  state_abbreviation IS NOT NULL
+  AND state_abbreviation NOT SIMILAR TO '[A-Z]{2}'
+ORDER BY
+  fips ;
 --^USA i Alabama nie maj¹ przypisanej wartoœci null
 --dla ujednolicenia przypisujê null tym polom
 --patrz: us_election_fixes.sql 
 
-
 --ponowne sprawdzenie wartoœci null
-select 
-	fips
-,	area_name 
-,	state_abbreviation 
-from county_facts cf 
-where state_abbreviation isnull
-order by fips ;
+ SELECT
+  fips ,
+  area_name ,
+  state_abbreviation
+FROM
+  county_facts cf
+WHERE
+  state_abbreviation isnull
+ORDER BY
+  fips ;
 
-select count(*)
-from county_facts cf 
-where state_abbreviation isnull ;
-
+SELECT count(*)
+FROM
+  county_facts cf
+WHERE
+  state_abbreviation isnull ;
 
 ----------------------------------------------------------------------------------
 --QUALITY CHECK TABLICY PRIMARY_RESULTS
 ---------------------------------------------------------------------------------- 
 
 --sprawdzenie, czy fips zawsze dodatni
-select *
-from primary_results pr 
-where fips <0 or fips isnull ;
+ SELECT *
+FROM
+  primary_results pr
+WHERE
+  fips <0
+  OR fips isnull ;
 
 --znalezienie potencjalnych wartoœci fips dla wierszy, w których wystêpuje null
-select pr.*
-,	concat(pr.county, ' County') as area_name,
-	(select cf.fips 
-		from county_facts cf 
-		where cf.area_name = concat(pr.county, ' County') 
-		and cf.state_abbreviation = pr.state_abbreviation) as potential_fips 
-from primary_results pr 
-where pr.fips <0 or pr.fips isnull ;
-
+ SELECT
+  pr.* ,
+  concat(
+    pr.county,
+    ' County'
+  ) AS area_name,
+  (
+    SELECT
+      cf.fips
+    FROM
+      county_facts cf
+    WHERE
+      cf.area_name = concat(
+        pr.county,
+        ' County'
+      )
+        AND cf.state_abbreviation = pr.state_abbreviation
+  ) AS potential_fips
+FROM
+  primary_results pr
+WHERE
+  pr.fips <0
+  OR pr.fips isnull ;
 --update tabeli
 --patrz: us_election_fixes.sql
 
 --ponowne sprawdzenie, czy fips zawsze dodatni
-select *
-from primary_results pr 
-where fips <0 or fips isnull ;
+ SELECT *
+FROM
+  primary_results pr
+WHERE
+  fips <0
+  OR fips isnull ;
 
 --sprawdzenie, czy skrót sk³ada siê zawsze z dwóch liter
-select 
-	count(*)
-,	case	when upper(state_abbreviation) similar to '[A-Z]{2}' then 'valid state abbr'
-			else 'invalid state abbr' end state_abbr_check
-from primary_results pr 
-group by state_abbr_check ;
+ SELECT
+  count(*) ,
+  CASE
+    WHEN upper(state_abbreviation) SIMILAR TO '[A-Z]{2}' THEN 'valid state abbr'
+    ELSE 'invalid state abbr'
+  END state_abbr_check
+FROM
+  primary_results pr
+GROUP BY
+  state_abbr_check ;
 
 --sprawdzenie, czy liczba stanów odpowiada liczbie skrótów
-select 
-	count(distinct state)
-,	count(distinct state_abbreviation)
-from primary_results pr ;
+ SELECT
+  count(DISTINCT state) ,
+  count(DISTINCT state_abbreviation)
+FROM
+  primary_results pr ;
 
 --sprawdzenie, czy skrót odpowiada nazwie stanu
-select 
-	state_abbreviation 
-,	state 
-from primary_results pr
-group by state_abbreviation, state
-order by state_abbreviation ;
+ SELECT
+  state_abbreviation ,
+  state
+FROM
+  primary_results pr
+GROUP BY
+  state_abbreviation,
+  state
+ORDER BY
+  state_abbreviation ;
 
 --sprawdzenie, czy stany maj¹ odpowiedniki w tabeli county_facts 
-select 
-	pr.state_abbreviation as state_abbr_pr
-,	pr.state 
-,	cf.state_abbreviation as state_abbr_cf
-from primary_results pr
-full join county_facts cf on pr.fips = cf.fips 
-group by pr.state_abbreviation, pr.state, cf.state_abbreviation 
-order by pr.state ;
-
+ SELECT
+  pr.state_abbreviation AS state_abbr_pr ,
+  pr.state ,
+  cf.state_abbreviation AS state_abbr_cf
+FROM
+  primary_results pr
+FULL JOIN county_facts cf ON
+  pr.fips = cf.fips
+GROUP BY
+  pr.state_abbreviation,
+  pr.state,
+  cf.state_abbreviation
+ORDER BY
+  pr.state ;
 
 --sprawdzenie brakuj¹cych odpowiedników fips w tabelach county_facts i primary_results
-select  
-	count(distinct pr.fips) as fips_not_in_county_facts
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where cf.fips isnull ;
+ SELECT count(DISTINCT pr.fips) AS fips_not_in_county_facts
+FROM
+  primary_results pr
+FULL JOIN county_facts cf ON
+  pr.fips = cf.fips
+WHERE
+  cf.fips isnull ;
+
 --z podzia³em na stany
-select distinct 
-	pr.state_abbreviation 
-,	count(pr.fips) as fips_not_in_county_facts
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where cf.fips isnull 
-group by pr.state_abbreviation ;
+ SELECT
+  DISTINCT pr.state_abbreviation ,
+  count(pr.fips) AS fips_not_in_county_facts
+FROM
+  primary_results pr
+FULL JOIN county_facts cf ON
+  pr.fips = cf.fips
+WHERE
+  cf.fips isnull
+GROUP BY
+  pr.state_abbreviation ;
 
 --^istnieje 7032 fipsów, niewystêpuj¹cych w county_facts
+ SELECT
+  count(DISTINCT cf.fips) AS fips_not_in_primary_results
+FROM
+  primary_results pr
+FULL JOIN county_facts cf ON
+  pr.fips = cf.fips
+WHERE
+  pr.fips isnull
+  AND cf.state_abbreviation IS NOT NULL ;
 
-select 
-	count(distinct cf.fips) as fips_not_in_primary_results
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where pr.fips isnull and cf.state_abbreviation is not null ;
 --z podzia³em na stany
-select distinct
-	cf.state_abbreviation 
-,	count(cf.fips) as fips_not_in_primary_results
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where pr.fips isnull and cf.state_abbreviation is not null 
-group by cf.state_abbreviation ;
-
+ SELECT
+  DISTINCT cf.state_abbreviation ,
+  count(cf.fips) AS fips_not_in_primary_results
+FROM
+  primary_results pr
+FULL JOIN county_facts cf ON
+  pr.fips = cf.fips
+WHERE
+  pr.fips isnull
+  AND cf.state_abbreviation IS NOT NULL
+GROUP BY
+  cf.state_abbreviation ;
 --^istnieje 335 fipsów niewystêpuj¹cych w primary_results 
 --(niebêd¹cych nullami, czyli US lub ca³ymi stanami - te bêd¹ pozostawione)
-
 --usuniêcie fipsów bez odpowiedników
---poni¿sze zapytanie powinno zwracaæ 7032 i 335:
-select  
-	count(pr.fips) as fips_not_in_county_facts
-,	count(cf.fips) as fips_not_in_primary_results
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where cf.fips isnull or pr.fips isnull and cf.state_abbreviation is not null ;
 
+--poni¿sze zapytanie powinno zwracaæ 7032 i 335:
+ SELECT
+  count(pr.fips) AS fips_not_in_county_facts ,
+  count(cf.fips) AS fips_not_in_primary_results
+FROM
+  primary_results pr
+FULL JOIN county_facts cf ON
+  pr.fips = cf.fips
+WHERE
+  cf.fips isnull
+  OR pr.fips isnull
+  AND cf.state_abbreviation IS NOT NULL ;
 --zapytania delete patrz: us_election_fixes.sql
 
 --po usuniêciu poni¿sze zapytanie powinno zwracaæ zera:
-select  
-	count(pr.fips) as fips_not_in_county_facts
-,	count(cf.fips) as fips_not_in_primary_results
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where cf.fips isnull or pr.fips isnull and cf.state_abbreviation is not null ;
+ SELECT
+  count(pr.fips) AS fips_not_in_county_facts ,
+  count(cf.fips) AS fips_not_in_primary_results
+FROM
+  primary_results pr
+FULL JOIN county_facts cf ON
+  pr.fips = cf.fips
+WHERE
+  cf.fips isnull
+  OR pr.fips isnull
+  AND cf.state_abbreviation IS NOT NULL ;
 
+--sprawdzenie, czy istniej¹ hrabstwa, w których nie oddano g³osów
+ SELECT
+  fips ,
+  state,
+  county ,
+  sum(votes) OVER (
+    PARTITION BY fips
+  )
+FROM
+  primary_results pr
+ORDER BY
+  4 ;
 
+--^w hrabstwie Carroll w Arkansas nie oddano g³osów --> usuwam te rekordy z tabel
+--zapytania delete patrz: us_election_fixes.sql
 

--- a/structure/us_election_fixes.sql
+++ b/structure/us_election_fixes.sql
@@ -1,35 +1,93 @@
-/*Wszystkie zapytania na podstawie, których stworzone zosta³y updaty/delety znajduj¹ siê w pliku us_election_data_quality_check.sql*/
+/*Wszystkie zapytania na podstawie, których stworzone zosta³y updaty/delety znajduj¹ siê w pliku us_election_data_quality_check.sql*/;
 
 /*update tabeli county_facts, aby wszystkie stany mia³y wartoœæ null w polu state_abbreviation
 (z zapytañ w us_election_data_quality_check.sql wiemy, ¿e nale¿y null przypisaæ do 'United States' i 'Alabama')*/
-update county_facts set state_abbreviation = null 
-where area_name = 'United States' or area_name = 'Alabama' ;
+UPDATE
+  county_facts
+SET
+  state_abbreviation = NULL
+WHERE
+  area_name = 'United States'
+  OR area_name = 'Alabama' ;
 
 /*uzupe³nienie wartoœci fips w tabeli primary_results na podstawie znalezionych odpowiadaj¹cych wartoœci w county_facts */
-update primary_results pr
-set fips = (
-	select cf.fips 
-	from county_facts cf 
-	where cf.area_name = concat(pr.county, ' County') 
-	and cf.state_abbreviation = pr.state_abbreviation)
-where pr.fips isnull ;
+UPDATE
+  primary_results pr
+SET
+  fips = (
+    SELECT
+      cf.fips
+    FROM
+      county_facts cf
+    WHERE
+      cf.area_name = concat(pr.county, ' County')
+        AND cf.state_abbreviation = pr.state_abbreviation
+  )
+WHERE
+  pr.fips ISNULL ;
 
 /*usuniêcie wierszy, dla których primary_results.fips nie ma odpowiednika county_facts.fips*/
-delete from primary_results 
-where fips in (
-select  
-	pr.fips 
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where cf.fips isnull
-) ;
+DELETE
+FROM
+  primary_results
+WHERE
+  fips IN (
+    SELECT
+      pr.fips
+    FROM
+      primary_results pr
+    FULL JOIN county_facts cf ON
+      pr.fips = cf.fips
+    WHERE
+      cf.fips ISNULL
+  ) ;
 
 /*usuniêcie wierszy, dla których county_facts.fips nie ma odpowiednika primary_results.fips */
-delete from county_facts 
-where fips in (
-select  
-	cf.fips 
-from primary_results pr 
-full join county_facts cf on pr.fips = cf.fips 
-where pr.fips isnull and cf.state_abbreviation is not null
+DELETE
+FROM
+  county_facts
+WHERE
+  fips IN (
+    SELECT
+      cf.fips
+    FROM
+      primary_results pr
+    FULL JOIN county_facts cf ON
+      pr.fips = cf.fips
+    WHERE
+      pr.fips ISNULL
+      AND cf.state_abbreviation IS NOT NULL
+  ) ;
+
+/*usuniêcie wierszy dla hrabstwa, w którym nie oddano g³osów*/
+DELETE
+FROM
+primary_results
+WHERE
+fips IN (
+  SELECT fips
+  FROM
+    primary_results pr
+  GROUP BY
+    fips,
+    state,
+    county
+  HAVING
+    sum(votes) = 0
 ) ;
+
+DELETE
+FROM
+  county_facts
+WHERE
+  fips IN (
+    SELECT fips
+    FROM
+      primary_results pr
+    GROUP BY
+      fips,
+      state,
+      county
+    HAVING
+      sum(votes) = 0
+  ) ;


### PR DESCRIPTION
Przy dalszej pracy nad projektem zauważyłam, że jest jeszcze jedno hrabstwo, dla którego nie zarejestrowano żadnego głosu. Powodowało to problemy przy np. obliczaniu procentów głosów na poszczególnych kandydatów (division by zero). Wobec tego zaktualizowałam plik z fixami o usunięcie wierszy dla tego hrabstwa. Przy okazji dla tych plików poprawiłam formatowanie.